### PR TITLE
chore: Add GitHub Actions CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,63 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Spring Boot 빌드
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Build Spring Boot app
+        run: |
+          cd backend
+          ./gradlew clean build -x test
+
+      # Docker Hub 로그인
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # Spring Docker 이미지 빌드 및 푸시
+      - name: Build and Push Spring Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/spring-app:latest
+
+      # Vue Docker 이미지 빌드 및 푸시
+      - name: Build and Push Vue Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/vue-app:latest
+
+      # EC2에 SSH로 접속하여 배포
+      - name: Deploy to EC2 instance
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            export DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}
+            cd ~/app
+            docker pull $DOCKER_USERNAME/spring-app:latest
+            docker pull $DOCKER_USERNAME/vue-app:latest
+            docker compose down
+            docker compose up -d


### PR DESCRIPTION
## #️⃣3 Docker CI/CD 환경 구축

> #3 

## 📝작업 내용

> 1. GitHub Actions 기반 CI/CD 워크플로우(ci-cd.yml) 생성
> -> main 브랜치에 push 발생 시 자동 실행
> EC2 서버에 SSH로 접속하여 이미지 pull 및 docker compose로 배포
> GitHub Secrets에 배포 정보 (DockerHub, EC2) 연동 완료